### PR TITLE
Add sprite renderer extensions and fix color calcs

### DIFF
--- a/Assets/Scripts/SpecificTweens.cs
+++ b/Assets/Scripts/SpecificTweens.cs
@@ -335,27 +335,17 @@ namespace ReMotion
 
             protected override Color AddOperator(Color left, Color right)
             {
-                return left + right;
+                return right;
             }
 
             protected override Color GetDifference(Color from, Color to)
             {
-                return new Color(
-                   to.a - from.a,
-                   to.r - from.r,
-                   to.g - from.g,
-                   to.b - from.b
-                );
+                return from - to;
             }
 
             protected override void CreateValue(ref Color from, ref Color difference, ref float ratio, out Color value)
             {
-                value = new Color(
-                    from.a + (difference.a * ratio),
-                    from.r + (difference.r * ratio),
-                    from.g + (difference.g * ratio),
-                    from.b + (difference.b * ratio)
-                );
+                value = Color.Lerp(from, from - difference, ratio);
             }
         }
     }

--- a/Assets/Scripts/TweenExtensions.cs
+++ b/Assets/Scripts/TweenExtensions.cs
@@ -192,6 +192,57 @@ namespace ReMotion.Extensions
         {
             return TweenColor(graphic, to, duration, easing, settings, isRelativeTo, autoStart: false).ToObservable();
         }
+        
+        /// <summary>Tween color alpha.</summary>
+        public static Tween<SpriteRenderer, float> TweenAlpha(this SpriteRenderer spriteRenderer, float to, float duration, EasingFunction easing = null, TweenSettings settings = null, bool isRelativeTo = false, bool autoStart = true)
+        {
+            settings = settings ?? TweenSettings.Default;
+            easing = easing ?? settings.DefaultEasing;
+
+            var tween = settings.UseFloatTween(spriteRenderer, x => x.color.a, (SpriteRenderer target, ref float value) =>
+            {
+                var x = target.color;
+                target.color = new Color { r = x.r, g = x.g, b = x.b, a = value };
+            }, easing, duration, to, isRelativeTo);
+
+            if (autoStart)
+            {
+                tween.Start();
+            }
+
+            return tween;
+        }
+
+        /// <summary>Tween color alpha.</summary>
+        public static IObservable<Unit> TweenAlphaAsync(this SpriteRenderer spriteRenderer, float to, float duration, EasingFunction easing = null, TweenSettings settings = null, bool isRelativeTo = false)
+        {
+            return TweenAlpha(spriteRenderer, to, duration, easing, settings, isRelativeTo, autoStart: false).ToObservable();
+        }
+
+        /// <summary>Tween color.</summary>
+        public static Tween<SpriteRenderer, Color> TweenColor(this SpriteRenderer spriteRenderer, Color to, float duration, EasingFunction easing = null, TweenSettings settings = null, bool isRelativeTo = false, bool autoStart = true)
+        {
+            settings = settings ?? TweenSettings.Default;
+            easing = easing ?? settings.DefaultEasing;
+
+            var tween = settings.UseColorTween(spriteRenderer, x => x.color, (SpriteRenderer target, ref Color value) =>
+            {
+                target.color = value;
+            }, easing, duration, to, isRelativeTo);
+
+            if (autoStart)
+            {
+                tween.Start();
+            }
+
+            return tween;
+        }
+
+        /// <summary>Tween color.</summary>
+        public static IObservable<Unit> TweenColorAsync(this SpriteRenderer spriteRenderer, Color to, float duration, EasingFunction easing = null, TweenSettings settings = null, bool isRelativeTo = false)
+        {
+            return TweenColor(spriteRenderer, to, duration, easing, settings, isRelativeTo, autoStart: false).ToObservable();
+        }
 
     }
 }


### PR DESCRIPTION
I have added the colors extension for the SpriteRenderer based on Graphic and have fixed the calculation of the color transition.

The calculation uses the opposite color that you want to arrive at with the current calculation.

Example:
```C#
private void Start()
{
    GetComponent<SpriteRenderer>()
        .TweenColor(Color.green, 1f, EasingFunctions.Linear, TweenSettings.CycleOnce, true, false)
        .StartFrom(Color.white);
}
```